### PR TITLE
Fix `RunTimeInSeconds` rounding issue

### DIFF
--- a/honeycomb/honeycomb_reporter.go
+++ b/honeycomb/honeycomb_reporter.go
@@ -1,7 +1,7 @@
 package honeycomb
 
 import (
-	"strconv"
+	"fmt"
 	"strings"
 
 	"github.com/cloudfoundry/custom-cats-reporters/honeycomb/client"
@@ -44,7 +44,7 @@ func (hr honeyCombReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 		specEvent.ComponentType = getComponentType(specSummary.Failure.ComponentType)
 	}
 	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStatePassed {
-		specEvent.RunTimeInSeconds = strconv.Itoa(int(specSummary.RunTime.Seconds()))
+		specEvent.RunTimeInSeconds = fmt.Sprintf("%f", specSummary.RunTime.Seconds())
 	}
 	// intentionally drop all errors to satisfy reporter interface
 	// and avoid unnecessary noise when an event cannot be sent to honeycomb

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Honeycomb Reporter", func() {
 						},
 						ComponentType: types.SpecComponentTypeIt,
 					},
-					RunTime: 1 * time.Second,
+					RunTime: 1234 * time.Millisecond,
 				}
 				honeycombReporter.SpecDidComplete(&specSummary)
 
@@ -77,7 +77,7 @@ var _ = Describe("Honeycomb Reporter", func() {
 					FailureLocation:       "failure-location-file-name:77",
 					ComponentCodeLocation: "component-location-file-name:2",
 					ComponentType:         "it",
-					RunTimeInSeconds:      "1",
+					RunTimeInSeconds:      "1.234000",
 				}))
 			})
 		})
@@ -89,7 +89,7 @@ var _ = Describe("Honeycomb Reporter", func() {
 					State:          types.SpecStatePassed,
 					CapturedOutput: "some-test-output",
 					ComponentTexts: []string{"some-it-description", "some-context-description", "some-describe-description"},
-					RunTime:        1 * time.Second,
+					RunTime:        1234 * time.Millisecond,
 				}
 				honeycombReporter.SpecDidComplete(&specSummary)
 
@@ -98,7 +98,7 @@ var _ = Describe("Honeycomb Reporter", func() {
 				Expect(specEventArgs).To(Equal(honeycomb.SpecEvent{
 					Description:      "some-it-description | some-context-description | some-describe-description",
 					State:            "passed",
-					RunTimeInSeconds: "1",
+					RunTimeInSeconds: "1.234000",
 				}))
 			})
 		})


### PR DESCRIPTION
The previous `RunTimeInSeconds` rounds to a whole second. This could lead to a loss of information when tests run in ms/ns.